### PR TITLE
Add validation method for too many vertex connections

### DIFF
--- a/bamboo/exporter.py
+++ b/bamboo/exporter.py
@@ -242,6 +242,23 @@ class Exporter:
                 endDot.findCutout(edge.id).name,
                 edge.length))
 
+    # Check that the dots collected from the DAG are likely to work as a dot to dot output.
+    def validateDots(self):
+
+        maxShapes = len(Cutout.shapeMap)
+
+        for vertex in self.vertices:
+
+            # A vertex cannot have more edges than the shape cutout map.
+            if len(vertex.connectedEdges) > maxShapes:
+                raise Exception("""
+
+Vertex {0} has more than {1} connections.
+Use Display -> Polygons -> Component IDs -> Vertices to see the vertex IDs.
+
+                                """.format(vertex.id, maxShapes))
+
+
     def export(self, outputFile):
 
         cmds.file(rename=outputFile)
@@ -269,6 +286,8 @@ class Exporter:
                 break
 
             dagIterator.next()
+
+        self.validateDots()
 
         self.constructDots()
 


### PR DESCRIPTION
This catches problems like #1 and provides a message to diagnose the problem. @Tom-McDonagh this usually means you have to go and fix the vertex which has too many connections. The max is currently 4 connections per dot, (square, triangle, pentagon, circle).

I use this menu option to see the vertex id:
![screen shot 2015-05-07 at 21 38 16](https://cloud.githubusercontent.com/assets/4549425/7525498/cd4ac9c8-f501-11e4-8236-cdb817a4acdf.png)

And I would recommend using the target weld from the Modelling Toolkit to blast those pesky vertices cleanly:
![screen shot 2015-05-07 at 21 42 16](https://cloud.githubusercontent.com/assets/4549425/7525532/1887088e-f502-11e4-9a6b-88e519d842ac.png)
